### PR TITLE
Added schemas for case management tables

### DIFF
--- a/server/db/schema/case_managers.sql
+++ b/server/db/schema/case_managers.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS case_managers;
+
+CREATE TYPE role AS ENUM ('superadmin', 'admin', 'case manager', 'intern');
+
+CREATE TABLE case_managers(
+	id VARCHAR(256) NOT NULL PRIMARY KEY,
+	role role NOT NULL,
+	first_name VARCHAR(16) NOT NULL,
+	last_name VARCHAR(16) NOT NULL,
+	phone_number VARCHAR(10) NOT NULL,
+	email VARCHAR(32) NOT NULL
+);

--- a/server/db/schema/locations.sql
+++ b/server/db/schema/locations.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS locations;
+
+CREATE TABLE locations(
+	id INT NOT NULL PRIMARY KEY,
+	cm_id VARCHAR(256) NOT NULL,
+	name VARCHAR(64) NOT NULL,
+	date date NOT NULL,
+	caloptima_funded BOOLEAN NOT NULL,
+	FOREIGN KEY (cm_id) REFERENCES case_managers(id)
+);

--- a/server/db/schema/units.sql
+++ b/server/db/schema/units.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS units;
+
+CREATE TYPE type AS ENUM ('family', 'single');
+
+CREATE TABLE units(
+	id INT NOT NULL PRIMARY KEY,
+	location_id INT NOT NULL,
+	name VARCHAR(64) NOT NULL,
+	type type NOT NULL,
+	FOREIGN KEY (location_id) REFERENCES locations(id)
+);


### PR DESCRIPTION
## Description
Added schemas for case_managers, locations, and units tables.

## Issues
Closes #5 

## Screenshots/Media

Schema SQL:

<img width="614" alt="Screenshot 2024-11-27 at 5 36 12 PM" src="https://github.com/user-attachments/assets/4706a1ea-890c-4408-895a-78ba0a024c8d">

Queries:

<img width="740" alt="Screenshot 2024-11-27 at 5 37 07 PM" src="https://github.com/user-attachments/assets/e5c87cf8-0bb6-43ab-a3c0-132caeefdf20">

Outputs:

<img width="1463" alt="Screenshot 2024-11-27 at 5 37 49 PM" src="https://github.com/user-attachments/assets/2f45389e-da9d-4201-a2f9-c492b331a86e">

## Additional Notes
- We changed the cm_id type from INT to VARCHAR(256) because it's referencing id in case_managers but the id type is VARCHAR(256). Let us know if it should be INT instead.
