### PR TITLE
Create case manager monthly stats table page & backend endpoints

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -27,6 +27,7 @@ import { BackendProvider } from "./contexts/BackendContext";
 import { RoleProvider } from "./contexts/RoleContext";
 import { FrontDeskMonthlyStats } from "./components/front_desk/monthlyStats"
 import { ClientInterviewScreening } from "./components/clientInterviewScreening/ClientInterviewScreening";
+import { CaseManagerMonthlyStats } from "./components/caseManagerMonthlyStats/CaseManagerMonthlyStats";
 // import { Comments } from "./compoenents/clientPage/Comments"
 
 
@@ -64,6 +65,10 @@ const App = () => {
                   path="/client-interview-screening"
                   element={<ClientInterviewScreening />}
                 /> 
+                <Route
+                  path="/monthly-statistics"
+                  element={<ProtectedRoute element={<CaseManagerMonthlyStats />} />}
+                />
                 <Route
                   path="/forms-table"
                   element={<FormTable />}

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -30,7 +30,9 @@ export const Navbar = (role: User["role"]) => {
       return (
         <>
           {makeNavTabs("Dashboard", "/dashboard")}
-          {makeNavTabs("Forms and Tables", "/forms-and-tables")}
+          {makeNavTabs("Forms", "/forms-and-tables")}
+          {makeNavTabs("Monthly Statistics", "/monthly-statistics")}
+          {makeNavTabs("Donations", "/donations")}
           {makeNavTabs("Settings", "/settings")}
         </>
       );

--- a/client/src/components/caseManagerMonthlyStats/CaseManagerMonthlyStats.tsx
+++ b/client/src/components/caseManagerMonthlyStats/CaseManagerMonthlyStats.tsx
@@ -27,11 +27,14 @@ type StatsTableData = {
 export const CaseManagerMonthlyStats = () => {
   const [allTabData, setAllTabData] = useState<StatsTableData[]>([]);
   const { backend } = useBackendContext();
+  const startYear = 2025;
+  const currentYear = new Date().getFullYear();
+  const [selectedYear, setSelectedYear] = useState<number>(currentYear); // State for selected year
 
   useEffect(() => {
     const getData = async () => {
       try {
-        const response = await backend.get(`/calculateMonthlyStats/2025`);
+        const response = await backend.get(`/calculateMonthlyStats/${selectedYear}`);
         setAllTabData(response.data);
         console.log(response.data)
       } catch (error) {
@@ -39,7 +42,7 @@ export const CaseManagerMonthlyStats = () => {
       }
     };
     getData();
-  }, [backend]);
+  }, [backend, selectedYear]);
 
   const buttonStyle = {
     variant: "outline",
@@ -64,9 +67,14 @@ export const CaseManagerMonthlyStats = () => {
           <Button {...buttonStyle}>Start Front Desk Form</Button>
           <Button {...buttonStyle}>Start Case Manager Form</Button>
         </ButtonGroup>
-        <Select>
-          <option>2025</option>
-        </Select>
+        <Select
+          value={selectedYear}
+          onChange={(e) => setSelectedYear(Number(e.target.value))}
+        >
+        {Array.from({ length: currentYear - startYear + 1 }, (_, index) => currentYear - index).map(year => (
+          <option key={year} value={year}>{year}</option>
+        ))}
+      </Select>
       </HStack>
 
       <Tabs isFitted w="full">

--- a/client/src/components/caseManagerMonthlyStats/CaseManagerMonthlyStats.tsx
+++ b/client/src/components/caseManagerMonthlyStats/CaseManagerMonthlyStats.tsx
@@ -17,19 +17,14 @@ import {
 
 import { useBackendContext } from "../../contexts/hooks/useBackendContext.ts";
 import { StatsTable } from "./StatsTable.tsx";
-
-type StatsTableData = {
-  tabName: string;
-  tables: any[];
-};
-
+import type { TabData } from "../../types/monthlyStat.ts";
 
 export const CaseManagerMonthlyStats = () => {
-  const [allTabData, setAllTabData] = useState<StatsTableData[]>([]);
   const { backend } = useBackendContext();
   const startYear = 2025;
   const currentYear = new Date().getFullYear();
-  const [selectedYear, setSelectedYear] = useState<number>(currentYear); // State for selected year
+  const [allTabData, setAllTabData] = useState<TabData[]>([]);
+  const [selectedYear, setSelectedYear] = useState<number>(currentYear);
 
   useEffect(() => {
     const getData = async () => {
@@ -90,7 +85,7 @@ export const CaseManagerMonthlyStats = () => {
           <TabPanel>
             {allTabData.map((tab) => (
                 tab.tables.map((table) => (
-                    <StatsTable key={table.tableName} title={table.tableName} data={table.tableData} />
+                    <StatsTable key={table.tableName} table={table} />
                 ))
             ))}
           </TabPanel>
@@ -98,7 +93,7 @@ export const CaseManagerMonthlyStats = () => {
           {allTabData.map((tab) => (
               <TabPanel key={tab.tabName}>
                   {tab.tables.map((table) => (
-                      <StatsTable key={table.tableName} title={table.tableName} data={table.tableData} />
+                      <StatsTable key={table.tableName} table={table} />
                   ))}
               </TabPanel>
           ))}

--- a/client/src/components/caseManagerMonthlyStats/CaseManagerMonthlyStats.tsx
+++ b/client/src/components/caseManagerMonthlyStats/CaseManagerMonthlyStats.tsx
@@ -18,8 +18,11 @@ import {
 import { useBackendContext } from "../../contexts/hooks/useBackendContext.ts";
 import type { TabData } from "../../types/monthlyStat.ts";
 import { StatsTable } from "./StatsTable.tsx";
+import { useNavigate } from "react-router-dom";
 
 export const CaseManagerMonthlyStats = () => {
+  const navigate = useNavigate();
+
   const { backend } = useBackendContext();
   const startYear = 2025;
   const currentYear = new Date().getFullYear();
@@ -60,8 +63,18 @@ export const CaseManagerMonthlyStats = () => {
 
       <HStack alignSelf="end">
         <ButtonGroup size="sm">
-          <Button {...buttonStyle}>Start Front Desk Form</Button>
-          <Button {...buttonStyle}>Start Case Manager Form</Button>
+        <Button
+            {...buttonStyle}
+            onClick={() => navigate('/frontDesk')}
+          >
+            Start Front Desk Form
+          </Button>
+          <Button
+            {...buttonStyle}
+            onClick={() => navigate('/casemanager')}
+          >
+            Start Case Manager Form
+          </Button>
         </ButtonGroup>
         <Select
           value={selectedYear}

--- a/client/src/components/caseManagerMonthlyStats/CaseManagerMonthlyStats.tsx
+++ b/client/src/components/caseManagerMonthlyStats/CaseManagerMonthlyStats.tsx
@@ -1,0 +1,60 @@
+import {
+    Button,
+    ButtonGroup,
+    Heading,
+    HStack,
+    Select,
+    VStack,
+    Tabs, TabList, Tab, TabPanel, TabPanels, Text
+  } from "@chakra-ui/react";
+  import {StatsTable} from "./StatsTable.tsx";
+  
+  export const CaseManagerMonthlyStats = () => {
+    const buttonStyle = {
+      variant: "outline",
+      colorScheme: "blue",
+    };
+  
+    return (
+      <VStack
+        align="start"
+        sx={{ maxWidth: "100%", padding: "4%" }}
+      >
+        <VStack align="start" gap="10px">
+          <Heading>Monthly Statistics</Heading>
+          <Text fontSize="14px">Last Updated: MM/DD/YYYY HH:MM XX</Text>
+        </VStack>
+  
+        <HStack alignSelf="end">
+          <ButtonGroup size="sm">
+            <Button {...buttonStyle}>Start Front Desk Form</Button>
+            <Button {...buttonStyle}>Start Case Manager Form</Button>
+          </ButtonGroup>
+          <Select>
+            <option>2025</option>
+          </Select>
+        </HStack>
+  
+        <Tabs isFitted w="full">
+          <TabList whiteSpace="nowrap">
+            <Tab>All Statistics</Tab>
+            <Tab>Call and Office Visits</Tab>
+            <Tab>Interviews</Tab>
+            <Tab>Contacts</Tab>
+            <Tab>Donation & Pantry Visits</Tab>
+            <Tab>Birthdays</Tab>
+            <Tab>E&TH Food & Bus</Tab>
+            <Tab>Referrals</Tab>
+            <Tab>Misc.</Tab>
+          </TabList>
+  
+          <TabPanels>
+            <TabPanel>
+              <StatsTable/>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      </VStack>
+    );
+  };
+  

--- a/client/src/components/caseManagerMonthlyStats/CaseManagerMonthlyStats.tsx
+++ b/client/src/components/caseManagerMonthlyStats/CaseManagerMonthlyStats.tsx
@@ -1,60 +1,91 @@
+import { useEffect, useState } from "react";
+
 import {
-    Button,
-    ButtonGroup,
-    Heading,
-    HStack,
-    Select,
-    VStack,
-    Tabs, TabList, Tab, TabPanel, TabPanels, Text
-  } from "@chakra-ui/react";
-  import {StatsTable} from "./StatsTable.tsx";
-  
-  export const CaseManagerMonthlyStats = () => {
-    const buttonStyle = {
-      variant: "outline",
-      colorScheme: "blue",
+  Button,
+  ButtonGroup,
+  Heading,
+  HStack,
+  Select,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+
+import { useBackendContext } from "../../contexts/hooks/useBackendContext.ts";
+import { StatsTable } from "./StatsTable.tsx";
+
+export const CaseManagerMonthlyStats = () => {
+  const [allTables, setAllTables] = useState([]);
+  const { backend } = useBackendContext();
+
+  useEffect(() => {
+    const getData = async () => {
+      try {
+        const response = await backend.get(`/calculateMonthlyStats/2025`);
+        setAllTables(response.data);
+        console.log(response.data)
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      }
     };
-  
-    return (
+    getData();
+  }, [backend]);
+
+  const buttonStyle = {
+    variant: "outline",
+    colorScheme: "blue",
+  };
+
+  return (
+    <VStack
+      align="start"
+      sx={{ maxWidth: "100%", padding: "4%" }}
+    >
       <VStack
         align="start"
-        sx={{ maxWidth: "100%", padding: "4%" }}
+        gap="10px"
       >
-        <VStack align="start" gap="10px">
-          <Heading>Monthly Statistics</Heading>
-          <Text fontSize="14px">Last Updated: MM/DD/YYYY HH:MM XX</Text>
-        </VStack>
-  
-        <HStack alignSelf="end">
-          <ButtonGroup size="sm">
-            <Button {...buttonStyle}>Start Front Desk Form</Button>
-            <Button {...buttonStyle}>Start Case Manager Form</Button>
-          </ButtonGroup>
-          <Select>
-            <option>2025</option>
-          </Select>
-        </HStack>
-  
-        <Tabs isFitted w="full">
-          <TabList whiteSpace="nowrap">
-            <Tab>All Statistics</Tab>
-            <Tab>Call and Office Visits</Tab>
-            <Tab>Interviews</Tab>
-            <Tab>Contacts</Tab>
-            <Tab>Donation & Pantry Visits</Tab>
-            <Tab>Birthdays</Tab>
-            <Tab>E&TH Food & Bus</Tab>
-            <Tab>Referrals</Tab>
-            <Tab>Misc.</Tab>
-          </TabList>
-  
-          <TabPanels>
-            <TabPanel>
-              <StatsTable/>
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
+        <Heading>Monthly Statistics</Heading>
+        <Text fontSize="14px">Last Updated: MM/DD/YYYY HH:MM XX</Text>
       </VStack>
-    );
-  };
-  
+
+      <HStack alignSelf="end">
+        <ButtonGroup size="sm">
+          <Button {...buttonStyle}>Start Front Desk Form</Button>
+          <Button {...buttonStyle}>Start Case Manager Form</Button>
+        </ButtonGroup>
+        <Select>
+          <option>2025</option>
+        </Select>
+      </HStack>
+
+      <Tabs isFitted w="full">
+        <TabList whiteSpace="nowrap">
+          {/* "All Statistics" tab plus one tab for each table */}
+          <Tab key="all">All Statistics</Tab>
+          {allTables.map((table) => (
+            <Tab key={table.tabName}>{table.tabName}</Tab>
+          ))}
+        </TabList>
+        <TabPanels>
+          {/* All Statistics: render all tables */}
+          <TabPanel>
+            {allTables.map((table) => (
+              <StatsTable key={table.tabName} title={table.tabName} data={table.data} />
+            ))}
+          </TabPanel>
+          {/* Render each table in its own tab panel */}
+          {allTables.map((table) => ( 
+            <TabPanel key={table.tabName}>
+              <StatsTable title={table.tabName} data={table.data} />
+            </TabPanel>
+          ))}
+        </TabPanels>
+      </Tabs>
+    </VStack>
+  );
+};

--- a/client/src/components/caseManagerMonthlyStats/CaseManagerMonthlyStats.tsx
+++ b/client/src/components/caseManagerMonthlyStats/CaseManagerMonthlyStats.tsx
@@ -18,15 +18,21 @@ import {
 import { useBackendContext } from "../../contexts/hooks/useBackendContext.ts";
 import { StatsTable } from "./StatsTable.tsx";
 
+type StatsTableData = {
+  tabName: string;
+  tables: any[];
+};
+
+
 export const CaseManagerMonthlyStats = () => {
-  const [allTables, setAllTables] = useState([]);
+  const [allTabData, setAllTabData] = useState<StatsTableData[]>([]);
   const { backend } = useBackendContext();
 
   useEffect(() => {
     const getData = async () => {
       try {
         const response = await backend.get(`/calculateMonthlyStats/2025`);
-        setAllTables(response.data);
+        setAllTabData(response.data);
         console.log(response.data)
       } catch (error) {
         console.error("Error fetching data:", error);
@@ -67,22 +73,26 @@ export const CaseManagerMonthlyStats = () => {
         <TabList whiteSpace="nowrap">
           {/* "All Statistics" tab plus one tab for each table */}
           <Tab key="all">All Statistics</Tab>
-          {allTables.map((table) => (
-            <Tab key={table.tabName}>{table.tabName}</Tab>
+          {allTabData.map((tab) => (
+              <Tab key={tab.tabName}>{tab.tabName}</Tab>
           ))}
         </TabList>
         <TabPanels>
           {/* All Statistics: render all tables */}
           <TabPanel>
-            {allTables.map((table) => (
-              <StatsTable key={table.tabName} title={table.tabName} data={table.data} />
+            {allTabData.map((tab) => (
+                tab.tables.map((table) => (
+                    <StatsTable key={table.tableName} title={table.tableName} data={table.tableData} />
+                ))
             ))}
           </TabPanel>
           {/* Render each table in its own tab panel */}
-          {allTables.map((table) => ( 
-            <TabPanel key={table.tabName}>
-              <StatsTable title={table.tabName} data={table.data} />
-            </TabPanel>
+          {allTabData.map((tab) => (
+              <TabPanel key={tab.tabName}>
+                  {tab.tables.map((table) => (
+                      <StatsTable key={table.tableName} title={table.tableName} data={table.tableData} />
+                  ))}
+              </TabPanel>
           ))}
         </TabPanels>
       </Tabs>

--- a/client/src/components/caseManagerMonthlyStats/CaseManagerMonthlyStats.tsx
+++ b/client/src/components/caseManagerMonthlyStats/CaseManagerMonthlyStats.tsx
@@ -16,8 +16,8 @@ import {
 } from "@chakra-ui/react";
 
 import { useBackendContext } from "../../contexts/hooks/useBackendContext.ts";
-import { StatsTable } from "./StatsTable.tsx";
 import type { TabData } from "../../types/monthlyStat.ts";
+import { StatsTable } from "./StatsTable.tsx";
 
 export const CaseManagerMonthlyStats = () => {
   const { backend } = useBackendContext();
@@ -29,9 +29,10 @@ export const CaseManagerMonthlyStats = () => {
   useEffect(() => {
     const getData = async () => {
       try {
-        const response = await backend.get(`/calculateMonthlyStats/${selectedYear}`);
+        const response = await backend.get(
+          `/calculateMonthlyStats/${selectedYear}`
+        );
         setAllTabData(response.data);
-        console.log(response.data)
       } catch (error) {
         console.error("Error fetching data:", error);
       }
@@ -66,36 +67,53 @@ export const CaseManagerMonthlyStats = () => {
           value={selectedYear}
           onChange={(e) => setSelectedYear(Number(e.target.value))}
         >
-        {Array.from({ length: currentYear - startYear + 1 }, (_, index) => currentYear - index).map(year => (
-          <option key={year} value={year}>{year}</option>
-        ))}
-      </Select>
+          {Array.from(
+            { length: currentYear - startYear + 1 },
+            (_, index) => currentYear - index
+          ).map((year) => (
+            <option
+              key={year}
+              value={year}
+            >
+              {year}
+            </option>
+          ))}
+        </Select>
       </HStack>
 
-      <Tabs isFitted w="full">
+      <Tabs
+        isFitted
+        w="full"
+      >
         <TabList whiteSpace="nowrap">
           {/* "All Statistics" tab plus one tab for each table */}
           <Tab key="all">All Statistics</Tab>
           {allTabData.map((tab) => (
-              <Tab key={tab.tabName}>{tab.tabName}</Tab>
+            <Tab key={tab.tabName}>{tab.tabName}</Tab>
           ))}
         </TabList>
         <TabPanels>
           {/* All Statistics: render all tables */}
           <TabPanel>
-            {allTabData.map((tab) => (
-                tab.tables.map((table) => (
-                    <StatsTable key={table.tableName} table={table} />
-                ))
-            ))}
+            {allTabData.map((tab) =>
+              tab.tables.map((table) => (
+                <StatsTable
+                  key={table.tableName}
+                  table={table}
+                />
+              ))
+            )}
           </TabPanel>
           {/* Render each table in its own tab panel */}
           {allTabData.map((tab) => (
-              <TabPanel key={tab.tabName}>
-                  {tab.tables.map((table) => (
-                      <StatsTable key={table.tableName} table={table} />
-                  ))}
-              </TabPanel>
+            <TabPanel key={tab.tabName}>
+              {tab.tables.map((table) => (
+                <StatsTable
+                  key={table.tableName}
+                  table={table}
+                />
+              ))}
+            </TabPanel>
           ))}
         </TabPanels>
       </Tabs>

--- a/client/src/components/caseManagerMonthlyStats/StatsTable.tsx
+++ b/client/src/components/caseManagerMonthlyStats/StatsTable.tsx
@@ -132,24 +132,30 @@ export const StatsTable = ({ title, data }) => {
           </HStack>
         </HStack>
         <TableContainer>
-        <Table variant="striped">
-          <Thead>
-            <Tr>
-              <Th textAlign="left">Category</Th>
-              {monthNames.map((month) => (
-                <Th key={month} textAlign="center">
-                  {month}
-                </Th>
-              ))}
-              <Th textAlign="center">Total</Th>
-            </Tr>
-          </Thead>
-          <Tbody>
-              {Object.entries(data).map(([categoryName, categoryData]) => (
-                <Tr key={categoryName}>
-                  <Td textAlign="left">{categoryName}</Td>
+          <Table variant="striped">
+            <Thead>
+              <Tr>
+                <Th textAlign="left">Category</Th>
+                {monthNames.map((month) => (
+                  <Th
+                    key={month}
+                    textAlign="center"
+                  >
+                    {month}
+                  </Th>
+                ))}
+                <Th textAlign="center">Total</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {Object.entries(data).map(([key, categoryData]) => (
+                <Tr key={key}>
+                  <Td textAlign="left">{categoryData.categoryName}</Td>
                   {categoryData.entries.map((entry) => (
-                    <Td key={entry.name} textAlign="center">
+                    <Td
+                      key={entry.month}
+                      textAlign="center"
+                    >
                       {entry.count}
                     </Td>
                   ))}

--- a/client/src/components/caseManagerMonthlyStats/StatsTable.tsx
+++ b/client/src/components/caseManagerMonthlyStats/StatsTable.tsx
@@ -1,0 +1,155 @@
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  HStack,
+  IconButton,
+  Input, InputGroup, InputRightElement,
+  Table,
+  TableContainer,
+  Tbody,
+  Text,
+  Th,
+  Thead, Tr,
+  useNumberInput,
+  VStack,
+} from "@chakra-ui/react";
+
+import {
+  MdFileUpload,
+  MdHideSource,
+  MdOutlineManageSearch,
+  MdPushPin,
+  MdZoomIn,
+} from "react-icons/md";
+
+export const StatsTable = () => {
+  const { getInputProps, getIncrementButtonProps, getDecrementButtonProps } =
+    useNumberInput({
+      step: 1,
+      defaultValue: 100,
+      min: 1,
+      max: 100,
+    });
+
+  const inc = getIncrementButtonProps();
+  const dec = getDecrementButtonProps();
+  const input = getInputProps();
+
+  const buttonStyle = {
+    variant: "ghost",
+  };
+
+  return (
+    <VStack
+      align="start"
+      spacing="24px"
+      paddingTop="24px"
+    >
+      <Heading fontSize="20px">Calls and Office Visits</Heading>
+      <Box
+        borderWidth="1px"
+        borderRadius="12px"
+        width="100%"
+      >
+        <HStack
+          width="100%"
+          justify="space-between"
+          paddingLeft="16px"
+          paddingTop="8px"
+          paddingRight="16px"
+          paddingBottom="8px"
+        >
+          <HStack>
+            <Button
+              {...buttonStyle}
+              leftIcon={<MdHideSource />}
+            >
+              Hide fields
+            </Button>
+            <Button
+              {...buttonStyle}
+              leftIcon={<MdPushPin />}
+            >
+              Pin fields
+            </Button>
+            <MdZoomIn />
+            <Text>Zoom</Text>
+            <Flex maxW="163px">
+              <InputGroup>
+                <Input type="number" {...input} />
+                <InputRightElement children="%"/>
+              </InputGroup>
+              <Button
+                {...buttonStyle}
+                {...dec}
+              >
+                -
+              </Button>
+              <Button
+                {...buttonStyle}
+                {...inc}
+              >
+                +
+              </Button>
+            </Flex>
+          </HStack>
+          <HStack>
+            <IconButton
+              {...buttonStyle}
+              icon={<MdOutlineManageSearch />}
+              aria-label={"search"}
+            />
+            <Button
+              {...buttonStyle}
+              leftIcon={<MdFileUpload />}
+            >
+              Export
+            </Button>
+          </HStack>
+        </HStack>
+        <TableContainer>
+          <Table
+            variant="striped"
+          >
+            <Thead>
+              <Th textAlign="left">Category</Th>
+              <Th>January</Th>
+              <Th>February</Th>
+              <Th>March</Th>
+              <Th>April</Th>
+              <Th>May</Th>
+              <Th>June</Th>
+              <Th>July</Th>
+              <Th>August</Th>
+              <Th>September</Th>
+              <Th>October</Th>
+              <Th>November</Th>
+              <Th>December</Th>
+              <Th>Total</Th>
+            </Thead>
+            <Tbody>
+              <Tr>
+                <Th textAlign="center">Calls (includes dups)</Th>
+                <Th textAlign="center">1</Th>
+                <Th textAlign="center">1</Th>
+                <Th textAlign="center">1</Th>
+                <Th textAlign="center">1</Th>
+                <Th textAlign="center">1</Th>
+                <Th textAlign="center">1</Th>
+                <Th textAlign="center">1</Th>
+                <Th textAlign="center">1</Th>
+                <Th textAlign="center">1</Th>
+                <Th textAlign="center">1</Th>
+                <Th textAlign="center">1</Th>
+                <Th textAlign="center">1</Th>
+                <Th textAlign="center">1</Th>
+              </Tr>
+            </Tbody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </VStack>
+  );
+};

--- a/client/src/components/caseManagerMonthlyStats/StatsTable.tsx
+++ b/client/src/components/caseManagerMonthlyStats/StatsTable.tsx
@@ -145,15 +145,15 @@ export const StatsTable = ({ title, data }) => {
             </Tr>
           </Thead>
           <Tbody>
-              {Object.entries(data).map(([categoryName, category]) => (
+              {Object.entries(data).map(([categoryName, categoryData]) => (
                 <Tr key={categoryName}>
                   <Td textAlign="left">{categoryName}</Td>
-                  {category.entries.map((entry) => (
+                  {categoryData.entries.map((entry) => (
                     <Td key={entry.name} textAlign="center">
                       {entry.count}
                     </Td>
                   ))}
-                  <Td textAlign="center">{category.total}</Td>
+                  <Td textAlign="center">{categoryData.total}</Td>
                 </Tr>
               ))}
             </Tbody>

--- a/client/src/components/caseManagerMonthlyStats/StatsTable.tsx
+++ b/client/src/components/caseManagerMonthlyStats/StatsTable.tsx
@@ -19,6 +19,7 @@ import {
   useNumberInput,
   VStack,
 } from "@chakra-ui/react";
+import { useEffect } from "react";
 
 import {
   MdFileUpload,
@@ -40,6 +41,9 @@ export const StatsTable = ({ title, data }) => {
   const inc = getIncrementButtonProps();
   const dec = getDecrementButtonProps();
   const input = getInputProps();
+  useEffect(() => {
+    console.log(data);
+  }, [data]);
 
   const monthNames = [
     "January",

--- a/client/src/components/caseManagerMonthlyStats/StatsTable.tsx
+++ b/client/src/components/caseManagerMonthlyStats/StatsTable.tsx
@@ -29,6 +29,7 @@ import {
 } from "react-icons/md";
 
 import type { Table as StatsTableProps } from "../../types/monthlyStat.ts";
+import { downloadCSV } from "../../utils/downloadCSV.ts";
 
 export const StatsTable = ({ table }: { table: StatsTableProps }) => {
   const { tableName, tableData } = table;
@@ -62,6 +63,18 @@ export const StatsTable = ({ table }: { table: StatsTableProps }) => {
   const buttonStyle = {
     variant: "ghost",
   };
+
+  const csvHeaders = ["Category", ...monthNames, "Total"];
+  const csvData = Object.values(tableData).map((row) => {
+    return {
+      Category: row.categoryName,
+      ...row.monthlyCounts.reduce((acc, m) => {
+        acc[m.month] = m.count;
+        return acc;
+      }, {}),
+      Total: row.total,
+    };
+  });
 
   return (
     <VStack
@@ -129,6 +142,9 @@ export const StatsTable = ({ table }: { table: StatsTableProps }) => {
             <Button
               {...buttonStyle}
               leftIcon={<MdFileUpload />}
+              onClick={() =>
+                downloadCSV(csvHeaders, csvData, `${tableName}Stats.csv`)
+              }
             >
               Export
             </Button>

--- a/client/src/components/caseManagerMonthlyStats/StatsTable.tsx
+++ b/client/src/components/caseManagerMonthlyStats/StatsTable.tsx
@@ -5,13 +5,17 @@ import {
   Heading,
   HStack,
   IconButton,
-  Input, InputGroup, InputRightElement,
+  Input,
+  InputGroup,
+  InputRightElement,
   Table,
   TableContainer,
   Tbody,
+  Td,
   Text,
   Th,
-  Thead, Tr,
+  Thead,
+  Tr,
   useNumberInput,
   VStack,
 } from "@chakra-ui/react";
@@ -24,7 +28,7 @@ import {
   MdZoomIn,
 } from "react-icons/md";
 
-export const StatsTable = () => {
+export const StatsTable = ({ title, data }) => {
   const { getInputProps, getIncrementButtonProps, getDecrementButtonProps } =
     useNumberInput({
       step: 1,
@@ -37,6 +41,21 @@ export const StatsTable = () => {
   const dec = getDecrementButtonProps();
   const input = getInputProps();
 
+  const monthNames = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ];
+
   const buttonStyle = {
     variant: "ghost",
   };
@@ -47,7 +66,7 @@ export const StatsTable = () => {
       spacing="24px"
       paddingTop="24px"
     >
-      <Heading fontSize="20px">Calls and Office Visits</Heading>
+      <Heading fontSize="20px">{title}</Heading>
       <Box
         borderWidth="1px"
         borderRadius="12px"
@@ -78,8 +97,11 @@ export const StatsTable = () => {
             <Text>Zoom</Text>
             <Flex maxW="163px">
               <InputGroup>
-                <Input type="number" {...input} />
-                <InputRightElement children="%"/>
+                <Input
+                  type="number"
+                  {...input}
+                />
+                <InputRightElement children="%" />
               </InputGroup>
               <Button
                 {...buttonStyle}
@@ -110,42 +132,30 @@ export const StatsTable = () => {
           </HStack>
         </HStack>
         <TableContainer>
-          <Table
-            variant="striped"
-          >
-            <Thead>
+        <Table variant="striped">
+          <Thead>
+            <Tr>
               <Th textAlign="left">Category</Th>
-              <Th>January</Th>
-              <Th>February</Th>
-              <Th>March</Th>
-              <Th>April</Th>
-              <Th>May</Th>
-              <Th>June</Th>
-              <Th>July</Th>
-              <Th>August</Th>
-              <Th>September</Th>
-              <Th>October</Th>
-              <Th>November</Th>
-              <Th>December</Th>
-              <Th>Total</Th>
-            </Thead>
-            <Tbody>
-              <Tr>
-                <Th textAlign="center">Calls (includes dups)</Th>
-                <Th textAlign="center">1</Th>
-                <Th textAlign="center">1</Th>
-                <Th textAlign="center">1</Th>
-                <Th textAlign="center">1</Th>
-                <Th textAlign="center">1</Th>
-                <Th textAlign="center">1</Th>
-                <Th textAlign="center">1</Th>
-                <Th textAlign="center">1</Th>
-                <Th textAlign="center">1</Th>
-                <Th textAlign="center">1</Th>
-                <Th textAlign="center">1</Th>
-                <Th textAlign="center">1</Th>
-                <Th textAlign="center">1</Th>
-              </Tr>
+              {monthNames.map((month) => (
+                <Th key={month} textAlign="center">
+                  {month}
+                </Th>
+              ))}
+              <Th textAlign="center">Total</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+              {Object.entries(data).map(([categoryName, category]) => (
+                <Tr key={categoryName}>
+                  <Td textAlign="left">{categoryName}</Td>
+                  {category.entries.map((entry) => (
+                    <Td key={entry.name} textAlign="center">
+                      {entry.count}
+                    </Td>
+                  ))}
+                  <Td textAlign="center">{category.total}</Td>
+                </Tr>
+              ))}
             </Tbody>
           </Table>
         </TableContainer>

--- a/client/src/components/caseManagerMonthlyStats/StatsTable.tsx
+++ b/client/src/components/caseManagerMonthlyStats/StatsTable.tsx
@@ -19,7 +19,6 @@ import {
   useNumberInput,
   VStack,
 } from "@chakra-ui/react";
-import { useEffect } from "react";
 
 import {
   MdFileUpload,
@@ -29,7 +28,10 @@ import {
   MdZoomIn,
 } from "react-icons/md";
 
-export const StatsTable = ({ title, data }) => {
+import type { Table as StatsTableProps } from "../../types/monthlyStat.ts";
+
+export const StatsTable = ({ table }: { table: StatsTableProps }) => {
+  const { tableName, tableData } = table;
   const { getInputProps, getIncrementButtonProps, getDecrementButtonProps } =
     useNumberInput({
       step: 1,
@@ -41,9 +43,6 @@ export const StatsTable = ({ title, data }) => {
   const inc = getIncrementButtonProps();
   const dec = getDecrementButtonProps();
   const input = getInputProps();
-  useEffect(() => {
-    console.log(data);
-  }, [data]);
 
   const monthNames = [
     "January",
@@ -70,7 +69,7 @@ export const StatsTable = ({ title, data }) => {
       spacing="24px"
       paddingTop="24px"
     >
-      <Heading fontSize="20px">{title}</Heading>
+      <Heading fontSize="20px">{tableName}</Heading>
       <Box
         borderWidth="1px"
         borderRadius="12px"
@@ -152,18 +151,18 @@ export const StatsTable = ({ title, data }) => {
               </Tr>
             </Thead>
             <Tbody>
-              {Object.entries(data).map(([key, categoryData]) => (
+              {Object.entries(tableData).map(([key, tableRow]) => (
                 <Tr key={key}>
-                  <Td textAlign="left">{categoryData.categoryName}</Td>
-                  {categoryData.entries.map((entry) => (
+                  <Td textAlign="left">{tableRow.categoryName}</Td>
+                  {tableRow.monthlyCounts.map((monthlyCount) => (
                     <Td
-                      key={entry.month}
+                      key={monthlyCount.month}
                       textAlign="center"
                     >
-                      {entry.count}
+                      {monthlyCount.count}
                     </Td>
                   ))}
-                  <Td textAlign="center">{categoryData.total}</Td>
+                  <Td textAlign="center">{tableRow.total}</Td>
                 </Tr>
               ))}
             </Tbody>

--- a/client/src/types/monthlyStat.ts
+++ b/client/src/types/monthlyStat.ts
@@ -22,3 +22,29 @@ export type MonthlyStat = {
   noCallNoShows: number;
   other: string;
 };
+
+// TODO: create shared types for monthly stats so frontend and backend are in sync
+export type MonthlyCount = {
+	month: string;
+	count: number;
+}
+
+export type TableRow = {
+	categoryName: string;
+	monthlyCounts: MonthlyCount[];
+	total: number;
+}
+
+export interface TableData {
+  [key: string]: TableRow;
+}
+
+export type Table = {
+  tableName: string;
+  tableData: TableData;
+};
+
+export type TabData = {
+  tabName: string;
+  tables: Table[]
+}

--- a/client/src/types/monthlyStat.ts
+++ b/client/src/types/monthlyStat.ts
@@ -23,7 +23,6 @@ export type MonthlyStat = {
   other: string;
 };
 
-// TODO: create shared types for monthly stats so frontend and backend are in sync
 export type MonthlyCount = {
 	month: string;
 	count: number;

--- a/server/common/utils.ts
+++ b/server/common/utils.ts
@@ -89,6 +89,15 @@ const keysToCamel = (data: object | string[] | string) => {
   return data;
 };
 
+const getMonthName = (monthNumber: number): string => {
+  if (monthNumber < 1 || monthNumber > 12) {
+    throw new Error("Invalid month number. Must be between 1 and 12.");
+  }
+  const months = { 1: "January", 2: "February", 3: "March", 4: "April", 5: "May", 6: "June", 7: "July", 8: "August", 9: "September", 10: "October", 11: "November", 12: "December" };
+  return months[monthNumber];
+
+};
+
 export {
   isNumeric,
   isBoolean,
@@ -96,4 +105,5 @@ export {
   isAlphaNumeric,
   isPhoneNumber,
   keysToCamel,
+  getMonthName
 };

--- a/server/routes/calculateMonthlyStats.ts
+++ b/server/routes/calculateMonthlyStats.ts
@@ -338,7 +338,7 @@ const getBusPassesData = async (year: string): Promise<CaseManagersTable> => {
     return busPassesData;
 };
 
-const getETHFoodBusData = async (year: string): Promise<StatsTableData[]> => {
+const getFoodBusData = async (year: string): Promise<StatsTableData[]> => {
     const foodCardsData = await getFoodCardsData(year);
     const busPassesData = await getBusPassesData(year);
 
@@ -662,7 +662,7 @@ calculateMonthlyStats.get("/:year", async (req, res) => {
 	const contactsData = await getContactsData(year);
 	const donationPantryVisitsData = await getDonationPantryVisitsData(year);
 	const birthdaysData = await getBirthdaysData(year); // returns 2 tables: womens birthdays and kids birthdays
-  const ETHFoodBusData = await getETHFoodBusData(year); // returns 2 tables: food cards and bus passes
+  const foodBusData = await getFoodBusData(year); // returns 2 tables: food cards and bus passes
   const referralsData = await getReferralsData(year); // returns 2 tables: healthcare referrals for women and healthcare referrals for kids
   const miscData = await getMiscData(year); // returns 2 tables: babies born and women who enroll in school or a trade program while in CCH
 	const response : StatsTabData[] = [
@@ -688,7 +688,7 @@ calculateMonthlyStats.get("/:year", async (req, res) => {
 		},
 		{
 			"tabName": "E&TH Food & Bus",
-			"tables": ETHFoodBusData
+			"tables": foodBusData
 		},
     {
 			"tabName": "Referrals",

--- a/server/routes/calculateMonthlyStats.ts
+++ b/server/routes/calculateMonthlyStats.ts
@@ -1,0 +1,299 @@
+import { Router } from "express";
+
+import { getMonthName, keysToCamel } from "../common/utils";
+import { db } from "../db/db-pgp";
+
+type TableEntry = {
+	name: string;
+	count: number;
+}
+
+type StatsTable = {
+	entries: TableEntry[];
+	total: number;
+}
+
+type CallsAndOfficeVisitsStats = {
+  "Calls (includes dups)": StatsTable;
+  "Duplicated Calls": StatsTable;
+  "Total Number of Office Visits": StatsTable;
+}
+
+type InterviewsTable = {
+  "Number of Interviews Conducted": StatsTable;
+  "Number of Pos. Tests": StatsTable;
+  "Number of NCNS": StatsTable;
+  "Number of Others (too late, left)": StatsTable;
+  "Total Interviews Scheduled": StatsTable;
+}
+
+export const calculateMonthlyStats = Router();
+
+const getCallsAndOfficeVisitTable = async (year: string) => {
+	const query = `
+	SELECT 
+    m.month,
+    COALESCE(SUM(total_calls), 0) as total_calls,
+    COALESCE(SUM(total_unduplicated_calles), 0) as total_unduplicated_calles,
+    COALESCE(SUM(total_office_visits), 0) as total_office_visits
+	FROM generate_series(1, 12) AS m(month)
+	LEFT JOIN front_desk_monthly f ON EXTRACT(MONTH FROM f.date) = m.month 
+    AND EXTRACT(YEAR FROM f.date) = $1
+	GROUP BY m.month
+	ORDER BY m.month;`;
+
+	const data = await db.any(query, [year]);
+
+	const formattedData: CallsAndOfficeVisitsStats = {
+		"Calls (includes dups)": {
+			"entries": [],
+			"total": 0
+		},
+		"Duplicated Calls": {
+			"entries": [],
+			"total": 0
+		},
+		"Total Number of Office Visits": {
+			"entries": [],
+			"total": 0
+		}
+	}
+
+	data.forEach((entry) => {
+		const monthName = getMonthName(entry.month)
+
+		const total_calls = Number(entry.total_calls)
+		const total_unduplicated_calls = Number(entry.total_unduplicated_calles)
+		const total_office_visits = Number(entry.total_office_visits)
+
+		// Calls including duplicates
+		formattedData["Calls (includes dups)"].entries.push({
+			"name": monthName,
+			"count": total_calls
+		})
+		formattedData["Calls (includes dups)"].total += total_calls
+
+		// Duplicated calls (total - unduplicated)
+		formattedData["Duplicated Calls"].entries.push({
+			"name": monthName,
+			"count": total_unduplicated_calls
+		})
+		formattedData["Duplicated Calls"].total += total_unduplicated_calls
+
+		// Total number of office visits
+		formattedData["Total Number of Office Visits"].entries.push({
+			"name": monthName,
+			"count": total_office_visits
+		})
+		formattedData["Total Number of Office Visits"].total += total_office_visits
+	})
+
+	return formattedData;
+};
+
+const getInterviewsTable = async (year: string) => {
+	const query = `SELECT 
+	m.month,
+	COALESCE(SUM(interviews_conducted), 0) as interviews_conducted,
+	COALESCE(SUM(positive_tests), 0) as positive_tests,
+	COALESCE(SUM(no_call_no_shows), 0) as no_call_no_shows,
+	COALESCE(SUM(other), 0) as other,
+	COALESCE(SUM(interviews_scheduled), 0) as interviews_scheduled
+FROM generate_series(1, 12) AS m(month)
+LEFT JOIN cm_monthly_stats f ON EXTRACT(MONTH FROM f.date) = m.month 
+	AND EXTRACT(YEAR FROM f.date) = $1
+GROUP BY m.month
+ORDER BY m.month;`;
+
+	const data = await db.any(query, [year]);
+
+	const formattedData: InterviewsTable = {
+		"Number of Interviews Conducted": {
+			"entries": [],
+			"total": 0
+		},
+		"Number of Pos. Tests": {
+			"entries": [],
+			"total": 0
+		},
+		"Number of NCNS": {
+			"entries": [],
+			"total": 0
+		},
+		"Number of Others (too late, left)": {
+			"entries": [],
+			"total": 0
+		},
+		"Total Interviews Scheduled": {
+			"entries": [],
+			"total": 0
+		}
+	}
+
+	data.forEach((entry) => {
+		const monthName = getMonthName(entry.month);
+
+		const interviewsConducted = Number(entry.interviews_conducted)
+		const positiveTests = Number(entry.positive_tests)
+		const noCallNoShows = Number(entry.no_call_no_shows)
+		const other = Number(entry.other)
+		const interviewsScheduled = Number(entry.interviews_scheduled)
+
+		formattedData["Number of Interviews Conducted"].entries.push({
+			"name": monthName,
+			"count": interviewsConducted
+		})
+		formattedData["Number of Interviews Conducted"].total += interviewsConducted
+
+		formattedData["Number of Pos. Tests"].entries.push({
+			"name": monthName,
+			"count": positiveTests
+		})
+		formattedData["Number of Pos. Tests"].total += positiveTests
+
+		formattedData["Number of NCNS"].entries.push({
+			"name": monthName,
+			"count": noCallNoShows
+		})
+		formattedData["Number of NCNS"].total += noCallNoShows
+		
+		formattedData["Number of Others (too late, left)"].entries.push({
+			"name": monthName,
+			"count": other
+		})
+		formattedData["Number of Others (too late, left)"].total += other
+
+		formattedData["Total Interviews Scheduled"].entries.push({
+			"name": monthName,
+			"count": interviewsScheduled
+		})
+		formattedData["Total Interviews Scheduled"].total += interviewsScheduled
+	})
+
+	return formattedData
+}
+
+const getWomensBirthdaysCelebratedTable = async (year) => {
+	const query = `SELECT 
+    m.month, 
+    cm.id AS cm_id, 
+    cm.first_name, 
+    cm.last_name, 
+    COALESCE(SUM(s.womens_birthdays), 0) AS womens_birthdays
+FROM 
+    generate_series(1, 12) AS m(month) 
+CROSS JOIN 
+    case_managers cm
+LEFT JOIN 
+    cm_monthly_stats s 
+    ON EXTRACT(MONTH FROM s.date) = m.month 
+    AND EXTRACT(YEAR FROM s.date) = $1 
+    AND s.cm_id = cm.id 
+GROUP BY 
+    m.month, cm.id, cm.first_name, cm.last_name 
+ORDER BY 
+    cm.id, m.month;`;
+
+	const data = await db.any(query, [year]);
+	const formattedData = {}
+
+	data.map((entry) => {
+		const name = `${entry.first_name} ${entry.last_name}`
+
+		if(!(name in formattedData)) {
+			formattedData[name] = {
+				"entries": [],
+				"total": 0
+			}
+		}
+
+		const monthName = getMonthName(entry.month);
+		const womensBirthdays = Number(entry.womens_birthdays)
+
+		formattedData[name].entries.push({
+			"name": monthName,
+			"count": womensBirthdays
+		})
+		formattedData[name].total += womensBirthdays
+	})
+
+	return formattedData
+}
+
+const getETHFoodBusTable = async (year) => {
+	// if case managers have the same first and last name, their stats will be combined lol
+	const query = `
+		SELECT 
+      m.month, 
+      cm.id AS cm_id, 
+      cm.first_name, 
+      cm.last_name, 
+      COALESCE(SUM(s.food_card_values), 0) AS food_cards,
+      COALESCE(SUM(s.bus_passes), 0) AS bus_passes
+    FROM 
+      generate_series(1, 12) AS m(month) 
+    CROSS JOIN 
+      case_managers cm
+    LEFT JOIN 
+      cm_monthly_stats s 
+      ON EXTRACT(MONTH FROM s.date) = m.month 
+      AND EXTRACT(YEAR FROM s.date) = $1
+      AND s.cm_id = cm.id 
+    GROUP BY 
+      m.month, cm.id, cm.first_name, cm.last_name 
+    ORDER BY 
+      cm.id, m.month;	`
+
+	const data = await db.any(query, [year]);
+	const formattedData = {}
+
+	data.forEach((entry) => {
+    const name = `${entry.first_name} ${entry.last_name}`;
+    
+    // Initialize case manager's stats if not exists
+    if (!(name in formattedData)) {
+      formattedData[name] = {
+        entries: [],
+        total: 0
+      };
+    }
+
+    const monthName = getMonthName(entry.month);
+    const foodCards = Number(entry.food_cards);
+
+    formattedData[name].entries.push({
+      name: monthName,
+      count: foodCards
+    });
+    
+    formattedData[name].total += foodCards
+  });
+
+  return formattedData;
+
+}
+
+
+calculateMonthlyStats.get("/:year", async (req, res) => {
+	const { year } = req.params
+	const callsAndOfficeVisitData = await getCallsAndOfficeVisitTable(year);
+	const interviewData = await getInterviewsTable(year);
+	const ETHFoodBusData = await getETHFoodBusTable(year);
+	const womensBirthdayData = await getWomensBirthdaysCelebratedTable(year);
+
+	const response = [
+		{
+			"tabName": "Calls and Office Visits",
+			"data": callsAndOfficeVisitData
+		},
+		{
+			"tabName": "Interviews",
+			"data": interviewData
+		},
+		{ "tabName": "just the food card table",
+			"data": ETHFoodBusData
+		}
+	]
+
+	res.status(200).json(response);
+});

--- a/server/routes/calculateMonthlyStats.ts
+++ b/server/routes/calculateMonthlyStats.ts
@@ -82,6 +82,7 @@ const getCallsAndOfficeVisitData = async (year: string): Promise<Table[]> => {
 
 		const total_calls = Number(entry.total_calls)
 		const total_unduplicated_calls = Number(entry.total_unduplicated_calles)
+		const total_duplicated_calls = total_calls - total_unduplicated_calls
 		const total_office_visits = Number(entry.total_office_visits)
 
 		callsAndOfficeVisitsTable["Calls (includes dups)"].monthlyCounts.push({
@@ -92,7 +93,7 @@ const getCallsAndOfficeVisitData = async (year: string): Promise<Table[]> => {
 
 		callsAndOfficeVisitsTable["Duplicated Calls"].monthlyCounts.push({
 			"month": monthName,
-			"count": total_unduplicated_calls
+			"count": total_duplicated_calls
 		})
 		callsAndOfficeVisitsTable["Duplicated Calls"].total += total_unduplicated_calls
 

--- a/server/routes/calculateMonthlyStats.ts
+++ b/server/routes/calculateMonthlyStats.ts
@@ -95,7 +95,7 @@ const getCallsAndOfficeVisitData = async (year: string): Promise<Table[]> => {
 			"month": monthName,
 			"count": total_duplicated_calls
 		})
-		callsAndOfficeVisitsTable["Duplicated Calls"].total += total_unduplicated_calls
+		callsAndOfficeVisitsTable["Duplicated Calls"].total += total_duplicated_calls
 
 		callsAndOfficeVisitsTable["Total Number of Office Visits"].monthlyCounts.push({
 			"month": monthName,

--- a/server/routes/calculateMonthlyStats.ts
+++ b/server/routes/calculateMonthlyStats.ts
@@ -415,36 +415,7 @@ const getWomensBirthdaysCelebratedData = async (year: string): Promise<TableData
 		womensBirthdaysCelebratedData[cmId].total += womensBirthdays
 	})
 
-  return womensBirthdaysCelebratedData
-
-// 	const totalMonthlyQuery = `SELECT
-//     m.month,
-//     COALESCE(SUM(s.womens_birthdays), 0) AS womens_birthdays
-// FROM
-//     generate_series(1, 12) AS m(month)
-// LEFT JOIN
-//     cm_monthly_stats s
-//     ON EXTRACT(MONTH FROM s.date) = m.month
-//     AND EXTRACT(YEAR FROM s.date) = $1
-// GROUP BY
-//     m.month
-// ORDER BY
-//     m.month;`
-
-// 	const totalMonthlyData = await db.any(query, [year]);
-// 	let totalMonthlyTotal = 0
-
-// 	formattedData["Total Monthly"] = {
-// 		"entries": totalMonthlyData.map((entry) => {
-// 			totalMonthlyTotal += Number(entry.womens_birthdays)
-
-// 			return {
-// 				"name": getMonthName(entry.month),
-// 				"count": Number(entry.womens_birthdays)
-// 			}
-// 		}),
-// 		"total": totalMonthlyTotal
-// 	}
+  return womensBirthdaysCelebratedData;
 
 }
 
@@ -463,7 +434,7 @@ const getChildrensBirthdaysCelebratedData = async (year: string): Promise<TableD
       FROM cm_monthly_stats
       WHERE EXTRACT(YEAR FROM date) = $1
       GROUP BY cm_id
-      HAVING SUM(childrens_birthdays) > 0 -- Ensure only those with childrens birthdays
+      HAVING SUM(childrens_birthdays) > 0
     ) active ON active.cm_id = cm.id
     CROSS JOIN generate_series(1, 12) AS m(month)
     LEFT JOIN cm_monthly_stats s ON s.cm_id = cm.id

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -22,6 +22,7 @@ import { usersRouter } from "../routes/users";
 import { verifyToken } from "./middleware";
 import { clientDataRouter } from "../routes/clientData";
 import { adminRouter } from "../routes/admin";
+import { calculateMonthlyStats } from "../routes/calculateMonthlyStats"; 
 
 dotenv.config();
 
@@ -67,6 +68,7 @@ app.use("/admin", adminRouter);
 app.use("/clientData", clientDataRouter);
 app.use("/screenerComment", screenerCommentRouter);
 app.use("/initialInterview", initialInterviewRouter);
+app.use("/calculateMonthlyStats", calculateMonthlyStats);
 
 app.listen(SERVER_PORT, () => {
   console.info(`Server listening on ${SERVER_PORT}`);


### PR DESCRIPTION
## Description

Created `/monthly-statistics` endpoint in the frontend to show the monthly statistics for case managers. Also created `/calculateMonthlyStats` backend endpoint to send all the table data to the frontend.

## Screenshots/Media

![image](https://github.com/user-attachments/assets/1b57d3de-6fec-4ce0-8352-efed308e827b)
![image](https://github.com/user-attachments/assets/1b2d3ed3-cca1-4af0-9441-7579a5dfbd3d)

## Issues
Closes #79

## Additional Notes / Questions
Some data wasn't found in the database, so empty tables were made for them.

Should we exclude case managers that have no statistics for the corresponding table? Our code has more complex queries to exclude case managers that have a cumulative total of 0 for the current table but we can simplify the queries if it turns out we should display every case manager for every table.

Can we have something set up so types can be shared across frontend and backend? No one's made a types file for the frontend and backend to share but for now we just copy pasted the backend types to the frontend types folder. What's the best practice way to share types?

total_unduplicated_calles should be renamed to total_unduplicated_calls in front_desk_monthly database, schema, frontdesk components, and the getCallsAndOfficeVisitData function we made. we wanted to change it but didn't want it to conflict with changes other ppl made so it might be best to fix this before next sprint tasks are assigned