### PR TITLE
Fixed styling in Front Desk monthly stats form to match figma

### DIFF
--- a/client/src/components/formsHub/FrontDeskTableBody.tsx
+++ b/client/src/components/formsHub/FrontDeskTableBody.tsx
@@ -53,6 +53,7 @@ export const FrontDeskMonthlyTableBody =  ({
       </Tr>
       <Tr>
         <Td fontSize="medium">Total # of Unduplicated Calls</Td>
+
         <Td>
           <NumberInputComponent
             name="totalUnduplicatedCalls"

--- a/client/src/components/front_desk/form.tsx
+++ b/client/src/components/front_desk/form.tsx
@@ -107,8 +107,8 @@ function FormFrontDesk({ onFormSubmitSuccess }: FormFrontDeskProps) {
 
   return (
     <>
-        <Box maxW="700px" marginX={"20%"}>
-            <Text justifySelf="center" fontSize={30} paddingBottom={"100px"}>
+        <Box maxW="100%" marginX={"20%"} justifyContent={"center"} >
+            <Text justifySelf="center" text-align="center" fontSize={30} paddingBottom={"50px"}>
                 <b>Front Desk Monthly Statistics Form</b>
             </Text>
             {generalFields.map(({ name, label }) => (
@@ -131,7 +131,7 @@ function FormFrontDesk({ onFormSubmitSuccess }: FormFrontDeskProps) {
                 />
                 </Box>
             ))}
-            <Text fontWeight={"bold"} p={2}>
+            <Text fontWeight={"bold"} p={2} paddingTop={"30px"} >
                 Huntington Beach (HB)
             </Text>
             {hbFields.map(({ name, label }) => (
@@ -154,7 +154,7 @@ function FormFrontDesk({ onFormSubmitSuccess }: FormFrontDeskProps) {
                 />
                 </Box>
             ))}
-            <Text fontWeight={"bold"} p={2}>
+            <Text fontWeight={"bold"} p={2}  paddingTop={"30px"}> 
                 Placentia
             </Text>
             {placentiaFields.map(({ name, label }) => (


### PR DESCRIPTION
## Description
Fixed some spacing in Front Desk Monthly Stats form to better match Figma design
## Screenshots/Media
![image](https://github.com/user-attachments/assets/1a63487a-d0b8-4b67-bb1d-bd461234ab68)

## Issues
Closes #151 

<!-- [Optional]
## Additional Notes
-->
